### PR TITLE
Zmena kurzoru na mape u udalostí

### DIFF
--- a/src/main/java/cz/larpovadatabaze/calendar/component/page/DetailOfEventPage.java
+++ b/src/main/java/cz/larpovadatabaze/calendar/component/page/DetailOfEventPage.java
@@ -112,6 +112,7 @@ public class DetailOfEventPage extends CsldBasePage {
         map.setStreetViewControlEnabled(false);
         map.setScaleControlEnabled(true);
         map.setScrollWheelZoomEnabled(true);
+        map.setOptions({draggableCursor:'pointer'});
 
         Event event = (Event)getDefaultModelObject();
         if(event.getLocation() != null) {


### PR DESCRIPTION
Bavili sme sa s Maníkom, že by bolo fajn, keby pri zadávaní udalostí na mape nebol kurzor ako pacička, keďže to ľudí zmätie a nevedie ich k tomu, aby do mapy klikli a zadali tak lokáciu. 
Keď tam bude pointer, mohlo by ich to lepšie naviesť k tomu kliknúť do mapy.

(snáď som správne pochopil GMaps API)