### PR TITLE
Allow event changes by anybody

### DIFF
--- a/src/main/java/cz/larpovadatabaze/calendar/service/GoogleCalendarEvents.java
+++ b/src/main/java/cz/larpovadatabaze/calendar/service/GoogleCalendarEvents.java
@@ -131,7 +131,8 @@ public class GoogleCalendarEvents {
     }
 
     private String getSubscriptionExpiration() {
-        return env.getProperty("calendar.subscription_expiration");
+        var res = env.getProperty("calendar.subscription_expiration");
+        return res == null ? "21600" : res;
     }
 
     private String getCalendarSyncUrl() {

--- a/src/main/java/cz/larpovadatabaze/games/services/sql/SqlFileImages.java
+++ b/src/main/java/cz/larpovadatabaze/games/services/sql/SqlFileImages.java
@@ -13,7 +13,10 @@ import org.apache.wicket.request.resource.ResourceReference;
 import org.hibernate.SessionFactory;
 import org.springframework.stereotype.Repository;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 
 /**
  *
@@ -70,7 +73,16 @@ public class SqlFileImages extends CRUD<Image, Integer> implements Images {
 
                         // Load
                         IEntityWithImage entity = dao.findById(id);
-                        getImageResource(entity).respond(attributes);
+                        if (entity != null) {
+                            getImageResource(entity).respond(attributes);
+                        } else {
+                            try {
+                                ((HttpServletResponse) attributes.getResponse().getContainerResponse()).sendError(404);
+                            }
+                            catch(IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
                     }
                 };
             }

--- a/src/main/java/cz/larpovadatabaze/graphql/fetchers/EventFetcherFactory.java
+++ b/src/main/java/cz/larpovadatabaze/graphql/fetchers/EventFetcherFactory.java
@@ -119,7 +119,7 @@ public class EventFetcherFactory {
 //             if (addedBy == null || !addedBy.getId().equals(appUsers.getLoggedUserId())) {
 //                 throw new GraphQLException(GraphQLException.ErrorCode.ACCESS_DENIED, "Must be editor or creator");
 //             }
-        }
+//        }
     }
 
     public DataFetcher<Event> createCreateEventFetcher() {

--- a/src/main/java/cz/larpovadatabaze/graphql/fetchers/EventFetcherFactory.java
+++ b/src/main/java/cz/larpovadatabaze/graphql/fetchers/EventFetcherFactory.java
@@ -112,12 +112,13 @@ public class EventFetcherFactory {
             return;
         }
 
-        if (!appUsers.isAtLeastEditor()) {
-            // Updating event and not editor - check user is creator
-            CsldUser addedBy = event.getAddedBy();
-            if (addedBy == null || !addedBy.getId().equals(appUsers.getLoggedUserId())) {
-                throw new GraphQLException(GraphQLException.ErrorCode.ACCESS_DENIED, "Must be editor or creator");
-            }
+//         commened by Manik 2021-06-03: We want to test if this will cause any issue in calendar usability        
+//         if (!appUsers.isAtLeastEditor()) {
+//             // Updating event and not editor - check user is creator
+//             CsldUser addedBy = event.getAddedBy();
+//             if (addedBy == null || !addedBy.getId().equals(appUsers.getLoggedUserId())) {
+//                 throw new GraphQLException(GraphQLException.ErrorCode.ACCESS_DENIED, "Must be editor or creator");
+//             }
         }
     }
 

--- a/src/test/java/cz/larpovadatabaze/graphql/fetchers/EventFetcherFactoryIT.java
+++ b/src/test/java/cz/larpovadatabaze/graphql/fetchers/EventFetcherFactoryIT.java
@@ -140,45 +140,46 @@ public class EventFetcherFactoryIT {
         assertThat(updatedEvent.getId(), equalTo(1));
     }
 
-    @Test
-    public void updateEventAsOtherUser() throws Exception {
-        CsldUser creator = new CsldUser();
-        creator.setId(123);
-
-        AppUsers mockAppUsers = mock(AppUsers.class);
-        when(mockAppUsers.isSignedIn()).thenReturn(true);
-        when(mockAppUsers.isAtLeastEditor()).thenReturn(false);
-        when(mockAppUsers.getLoggedUser()).thenReturn(creator);
-        when(mockAppUsers.getLoggedUserId()).thenReturn(creator.getId());
-
-        Event event = createEvent();
-        event.setId(1);
-        Events events = new InMemoryEvents();
-        events.saveOrUpdate(event);
-
-        Games games = new InMemoryGames();
-        Labels labels = new InMemoryLabels();
-
-        Map<String, Object> arguments = new HashMap<>();
-        Map<String, Object> input = createInput();
-        input.put("games", Collections.emptyList());
-        input.put("labels", Collections.emptyList());
-        arguments.put("input", input);
-
-        EventFetcherFactory factory = new EventFetcherFactory(events, games, labels, mockAppUsers, mockGoogleCalendarEvents);
-        DataFetcher<Event> dataFetcher = factory.createUpdateEventFetcher();
-        DataFetchingEnvironment dataFetchingEnvironment = new MockDataFetchingEnvironment(arguments, null);
-
-        try {
-            dataFetcher.get(dataFetchingEnvironment);
-            // Should throw
-            assertThat(1, equalTo(2));
-        }
-        catch(Exception e) {
-            assertThat(e.getClass(), equalTo(GraphQLException.class));
-
-            GraphQLException ex = (GraphQLException) e;
-            assertThat(ex.getCode(), equalTo(GraphQLException.ErrorCode.ACCESS_DENIED));
-        }
-    }
+//    commened by Manik 2021-06-03: We want to test if this will cause any issue in calendar usability
+//    @Test
+//    public void updateEventAsOtherUser() throws Exception {
+//        CsldUser creator = new CsldUser();
+//        creator.setId(123);
+//
+//        AppUsers mockAppUsers = mock(AppUsers.class);
+//        when(mockAppUsers.isSignedIn()).thenReturn(true);
+//        when(mockAppUsers.isAtLeastEditor()).thenReturn(false);
+//        when(mockAppUsers.getLoggedUser()).thenReturn(creator);
+//        when(mockAppUsers.getLoggedUserId()).thenReturn(creator.getId());
+//
+//        Event event = createEvent();
+//        event.setId(1);
+//        Events events = new InMemoryEvents();
+//        events.saveOrUpdate(event);
+//
+//        Games games = new InMemoryGames();
+//        Labels labels = new InMemoryLabels();
+//
+//        Map<String, Object> arguments = new HashMap<>();
+//        Map<String, Object> input = createInput();
+//        input.put("games", Collections.emptyList());
+//        input.put("labels", Collections.emptyList());
+//        arguments.put("input", input);
+//
+//        EventFetcherFactory factory = new EventFetcherFactory(events, games, labels, mockAppUsers, mockGoogleCalendarEvents);
+//        DataFetcher<Event> dataFetcher = factory.createUpdateEventFetcher();
+//        DataFetchingEnvironment dataFetchingEnvironment = new MockDataFetchingEnvironment(arguments, null);
+//
+//        try {
+//            dataFetcher.get(dataFetchingEnvironment);
+//            // Should throw
+//            assertThat(1, equalTo(2));
+//        }
+//        catch(Exception e) {
+//            assertThat(e.getClass(), equalTo(GraphQLException.class));
+//
+//            GraphQLException ex = (GraphQLException) e;
+//            assertThat(ex.getCode(), equalTo(GraphQLException.ErrorCode.ACCESS_DENIED));
+//        }
+//    }
 }


### PR DESCRIPTION
## Motivation / background
Our goal with new calendar is that everybody can add new event fast and easily. None the less, that will block the real event organizations from editing the event (as they are not creators) and they need to ask moderator (editor in the code speech) to update the event.

This is inconvenient and cumbersome flow. Thus, I would like to test what happens if we unlock the editing for everybody.

As we are community, we trust each other (to certain extend) and the usage of database/calendar is limited to active users only I believe this may not cause any issues. If there are some malicious users they can make some mess even now (by adding infinite amount of events). 

To prove this theory I would like to test it after public release. We also need to be smart while presenting such functionality (as it will be I will take care of that)

## Update
* Allow event edit to everybody